### PR TITLE
Update SPI.cs - spi mode 3 definition error

### DIFF
--- a/src/FtdiSharp/Protocols/SPI.cs
+++ b/src/FtdiSharp/Protocols/SPI.cs
@@ -34,10 +34,9 @@ public class SPI : ProtocolBase
         if (spiMode < 0 || spiMode > 3)
             throw new ArgumentException(nameof(spiMode));
 
-        ClockIdlesLow = spiMode == 0 || spiMode == 1;
-        SampleOnRisingClock = spiMode == 0 || spiMode == 2;
-        TransmitOnRisingClock = spiMode == 1 || spiMode == 3;
-
+        ClockIdlesLow = spiMode == 0 || spiMode == 1;  
+        SampleOnRisingClock = spiMode == 0 || spiMode == 3; 
+        TransmitOnRisingClock = spiMode == 1 || spiMode == 2; 
         FTDI_ConfigureMpsse(slowDownFactor);
         CsHigh();
     }


### PR DESCRIPTION
Probably bad definition of SPI modes, please check https://www.analog.com/en/resources/analog-dialogue/articles/introduction-to-spi-interface.html Table 1. 